### PR TITLE
Create a false commit to keep cron job from dying

### DIFF
--- a/.github/workflows/commit.yml
+++ b/.github/workflows/commit.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - master
+      - dev/create-false-commit
   schedule:
     - cron: '30 8 * * 0' # Every Sunday at 8:30AM UTC (5:30AM EST)
 

--- a/.github/workflows/commit.yml
+++ b/.github/workflows/commit.yml
@@ -1,0 +1,15 @@
+name: Commit
+
+on:
+  push:
+    branches:
+      - master
+  schedule:
+    - cron: '30 8 * * 0' # Every Sunday at 8:30AM UTC (5:30AM EST)
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: gautamkrishnar/keepalive-workflow@v1

--- a/.github/workflows/commit.yml
+++ b/.github/workflows/commit.yml
@@ -4,7 +4,6 @@ on:
   push:
     branches:
       - master
-      - dev/create-false-commit
   schedule:
     - cron: '30 8 * * 0' # Every Sunday at 8:30AM UTC (5:30AM EST)
 

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -2,7 +2,8 @@ name: Onceler Deploy
 
 on:
   push:
-    branches: [master]
+    branches:
+      - master
   schedule:
     - cron: '30 9 * * 0' # Every Sunday at 9:30AM UTC (5:30AM EST)
 
@@ -11,7 +12,8 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
+
       - name: Setup ruby installation
         uses: ruby/setup-ruby@v1
         with:


### PR DESCRIPTION
- Creating a commit once a week to prevent cron job from dying.