### PR TITLE
deps: update workflow dependencies and add cooldown

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -3,7 +3,9 @@ updates:
   - package-ecosystem: bundler
     directory: /
     schedule:
-      interval: daily
+      interval: monthly
+    cooldown:
+      default-days: 14
   - package-ecosystem: github-actions
     directory: /
     groups:
@@ -11,4 +13,6 @@ updates:
         patterns:
           - "*"
     schedule:
-      interval: daily
+      interval: monthly
+    cooldown:
+      default-days: 14

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -14,12 +14,12 @@ jobs:
       contents: read  # Read access to the repository contents
 
     steps:
-      - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           persist-credentials: false
 
       - name: Setup ruby installation
-        uses: ruby/setup-ruby@ab177d40ee5483edb974554986f56b33477e21d0 # v1.265.0
+        uses: ruby/setup-ruby@09a7688d3b55cf0e976497ff046b70949eeaccfd # v1.288.0
         with:
           bundler-cache: false
 


### PR DESCRIPTION
- Dependencies only update.
- Add cooldown to dependabot so we don't grab the latest and greatest without some time to cool off dependencies.