### PR TITLE
deps: lock dependencies to cloud.gov versions

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -9,6 +9,7 @@ on:
 
 jobs:
   deploy:
+    environment: prod
     runs-on: ubuntu-latest
     permissions:
       contents: read  # Read access to the repository contents
@@ -19,23 +20,15 @@ jobs:
           persist-credentials: false
 
       - name: Setup ruby installation
-        uses: ruby/setup-ruby@09a7688d3b55cf0e976497ff046b70949eeaccfd # v1.288.0
+        uses: ruby/setup-ruby@6ca151fd1bfcfd6fe0c4eb6837eb0584d0134a0c # v1.290.0
         with:
           bundler-cache: false
 
       - name: Deploy to cloud.gov
-        uses: cloud-gov/cg-cli-tools@main
+        uses: cloud-gov/cg-cli-tools@bafcd2b3d36984482c01b1dd2c3750b4f355b8a2 # 2026-03-05 Commit
         with:
           cf_api: ${{ secrets.CF_API }}
           cf_username: ${{ secrets.CF_USERNAME }}
           cf_password: ${{ secrets.CF_PASSWORD }}
           cf_org: ${{ secrets.CF_ORG }}
           cf_space: ${{ secrets.CF_SPACE }}
-
-      - name: Notify slack channel
-        uses: rtCamp/action-slack-notify@e31e87e03dd19038e411e38ae27cbad084a90661 # v2.3.3
-        env:
-          SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK }}
-          SLACK_MSG_AUTHOR: usds-bot
-          SLACK_MESSAGE: 'GH Actions: deployed Onceler :rocket:'
-          MSG_MINIMAL: true

--- a/Gemfile
+++ b/Gemfile
@@ -1,6 +1,6 @@
 source 'https://rubygems.org'
 
-ruby '~> 3.2.8'
+ruby '~> 3.2.10'
 
 gem 'sinatra'
 gem 'thin'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -8,9 +8,9 @@ GEM
     mustermann (3.0.4)
       ruby2_keywords (~> 0.0.1)
     nio4r (2.7.5)
-    puma (7.1.0)
+    puma (7.2.0)
       nio4r (~> 2.0)
-    rack (3.2.4)
+    rack (3.2.5)
     rack-protection (4.2.1)
       base64 (>= 0.1.0)
       logger (>= 1.6.0)
@@ -34,7 +34,7 @@ GEM
       eventmachine (~> 1.0, >= 1.0.4)
       logger
       rack (>= 1, < 4)
-    tilt (2.6.1)
+    tilt (2.7.0)
 
 PLATFORMS
   ruby
@@ -47,8 +47,26 @@ DEPENDENCIES
   sinatra
   thin
 
+CHECKSUMS
+  base64 (0.3.0) sha256=27337aeabad6ffae05c265c450490628ef3ebd4b67be58257393227588f5a97b
+  daemons (1.4.1) sha256=8fc76d76faec669feb5e455d72f35bd4c46dc6735e28c420afb822fac1fa9a1d
+  eventmachine (1.2.7) sha256=994016e42aa041477ba9cff45cbe50de2047f25dd418eba003e84f0d16560972
+  logger (1.7.0) sha256=196edec7cc44b66cfb40f9755ce11b392f21f7967696af15d274dde7edff0203
+  mustermann (3.0.4) sha256=85fadcb6b3c6493a8b511b42426f904b7f27b282835502233dd154daab13aa22
+  nio4r (2.7.5) sha256=6c90168e48fb5f8e768419c93abb94ba2b892a1d0602cb06eef16d8b7df1dca1
+  puma (7.2.0) sha256=bf8ef4ab514a4e6d4554cb4326b2004eba5036ae05cf765cfe51aba9706a72a8
+  rack (3.2.5) sha256=4cbd0974c0b79f7a139b4812004a62e4c60b145cba76422e288ee670601ed6d3
+  rack-protection (4.2.1) sha256=cf6e2842df8c55f5e4d1a4be015e603e19e9bc3a7178bae58949ccbb58558bac
+  rack-session (2.1.1) sha256=0b6dc07dea7e4b583f58a48e8b806d4c9f1c6c9214ebc202ec94562cbea2e4e9
+  rack-ssl-enforcer (0.2.9) sha256=99ef4051d1d1e8ca46bbeecb824506798db03e51db3028cb0acf9c18971b1108
+  rackup (2.3.1) sha256=6c79c26753778e90983761d677a48937ee3192b3ffef6bc963c0950f94688868
+  ruby2_keywords (0.0.5) sha256=ffd13740c573b7301cf7a2e61fc857b2a8e3d3aff32545d6f8300d8bae10e3ef
+  sinatra (4.2.1) sha256=b7aeb9b11d046b552972ade834f1f9be98b185fa8444480688e3627625377080
+  thin (2.0.1) sha256=5bbde5648377f5c3864b5da7cd89a23b5c2d8d8bb9435719f6db49644bcdade9
+  tilt (2.7.0) sha256=0d5b9ba69f6a36490c64b0eee9f6e9aad517e20dcc848800a06eb116f08c6ab3
+
 RUBY VERSION
-   ruby 3.2.8p263
+   ruby 3.2.10
 
 BUNDLED WITH
-   2.4.19
+   2.7.2

--- a/README.md
+++ b/README.md
@@ -27,26 +27,20 @@ Since Onceler stores secrets in volatile memory, it has no external
 dependencies and no database. All Ruby library dependencies are listed in the
 [Gemfile](./Gemfile).
 
-Onceler is written in Ruby. It requires Ruby >= 3.1.1.
+Onceler is written in Ruby. It requires Ruby >= 3.2.8.
 
 [Rbenv](https://github.com/rbenv/rbenv) provides a convenient way to manage
 installations of multiple Ruby versions.
 
 ## Maintenance
 
-- Update gem versions
-  `bundle update`
+- Install gem dependencies
+  `bundle install`
 
 - Update Bundler version
-  `bundle update --bundler`
+  `bundle update --bundler <version>`
 
 ## Running the app
-
-Install gem dependencies
-
-```bash
-bundle install
-```
 
 Start the application
 


### PR DESCRIPTION
- Updating dependencies per cloud.gov's cf pack file.
- Locking environment variables to env github.